### PR TITLE
Return a promise from updateElement

### DIFF
--- a/src/update-element.js
+++ b/src/update-element.js
@@ -2,7 +2,9 @@ import {getScheduler} from './scheduler-assignment'
 import performElementUpdate from './perform-element-update'
 
 export default function updateElement (component) {
-  getScheduler().updateDocument(function () {
+  let scheduler = getScheduler()
+  scheduler.updateDocument(function () {
     performElementUpdate(component)
   })
+  return scheduler.getNextUpdatePromise()
 }

--- a/test/unit/update-element.test.js
+++ b/test/unit/update-element.test.js
@@ -41,9 +41,7 @@ describe('etch.updateElement(component)', () => {
     expect(component.refs.greeted).to.be.undefined
 
     component.condition = false
-    etch.updateElement(component)
-
-    await etch.getScheduler().getNextUpdatePromise()
+    await etch.updateElement(component)
 
     expect(component.refs.greeted.textContent).to.equal('World')
     expect(component.refs.greeting).to.be.undefined


### PR DESCRIPTION
I've hit a few situations where I've needed to take action after an update has completed, usually things like registering new event listeners on newly available elements. I'm using `getNextUpdatePromise()` now, but it occurred to me that it would be convenient to return the update promise from `updateElement` directly:

```js
etch.updateElement(this).then(() => {
  // Use this.refs
})
```

A minor change, but one that would save callers from an extra import and read more nicely. What do you think?