### PR TITLE
Minor changes to tests. All tests pass.

### DIFF
--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -77,8 +77,7 @@ describe('etch.dom', () => {
 
             parentComponent.greeting = 'Goodnight'
             parentComponent.greeted = 'Moon'
-            etch.updateElement(parentComponent)
-            await etch.getScheduler().getNextUpdatePromise()
+            await etch.updateElement(parentComponent)
 
             expect(element.textContent).to.equal('Goodnight Moon')
             expect(element.firstChild).to.equal(initialChildElement)
@@ -119,8 +118,7 @@ describe('etch.dom', () => {
 
             parentComponent.greeting = 'Goodnight'
             parentComponent.greeted = 'Moon'
-            etch.updateElement(parentComponent)
-            await etch.getScheduler().getNextUpdatePromise()
+            await etch.updateElement(parentComponent)
 
             expect(element.textContent).to.equal('Goodnight Moon')
             expect(element.firstChild).not.to.equal(initialChildElement)
@@ -171,8 +169,7 @@ describe('etch.dom', () => {
           let initialChildElement = element.firstChild
 
           parentComponent.condition = false
-          etch.updateElement(parentComponent)
-          await etch.getScheduler().getNextUpdatePromise()
+          await etch.updateElement(parentComponent)
 
           expect(element.textContent).to.equal('B')
           expect(element.firstChild).not.to.equal(initialChildElement)
@@ -242,8 +239,7 @@ describe('etch.dom', () => {
           expect(childComponentB.updateCalled).to.be.false
 
           parentComponent.condition = false
-          etch.updateElement(parentComponent)
-          await etch.getScheduler().getNextUpdatePromise()
+          await etch.updateElement(parentComponent)
 
           expect(element.children[0]).to.equal(childElementB)
           expect(element.children[1]).to.equal(childElementA)
@@ -303,8 +299,7 @@ describe('etch.dom', () => {
         expect(parentComponent.refs.child.refs.self.textContent).to.equal('A')
 
         parentComponent.refName = 'kid'
-        etch.updateElement(parentComponent)
-        await etch.getScheduler().getNextUpdatePromise()
+        await etch.updateElement(parentComponent)
 
         expect(parentComponent.refs.child).to.be.undefined
         expect(parentComponent.refs.kid instanceof ChildComponentA).to.be.true
@@ -313,8 +308,7 @@ describe('etch.dom', () => {
 
         parentComponent.refName = 'child'
         parentComponent.condition = false
-        etch.updateElement(parentComponent)
-        await etch.getScheduler().getNextUpdatePromise()
+        await etch.updateElement(parentComponent)
 
         expect(parentComponent.refs.kid).to.be.undefined
         expect(parentComponent.refs.child instanceof ChildComponentB).to.be.true

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -247,6 +247,8 @@ describe('etch.dom', () => {
           expect(parentComponent.refs.a.element).to.equal(childElementA)
           expect(parentComponent.refs.b).to.equal(childComponentB)
           expect(parentComponent.refs.b.element).to.equal(childElementB)
+          expect(childComponentA.updateCalled).to.be.true
+          expect(childComponentB.updateCalled).to.be.true
         })
       })
     })

--- a/test/unit/update-element.test.js
+++ b/test/unit/update-element.test.js
@@ -16,9 +16,8 @@ describe('etch.updateElement(component)', () => {
     expect(element.textContent).to.equal('Hello World')
 
     component.greeting = 'Goodbye'
-    etch.updateElement(component)
 
-    await etch.getScheduler().getNextUpdatePromise()
+    await etch.updateElement(component)
 
     expect(element.textContent).to.equal('Goodbye World')
   })


### PR DESCRIPTION
Since `etch.updateElement(component)` returns the next update promise, I reduced 
```javascript 
etch.updateElement(parentComponent)		
await etch.updateElement(parentComponent)
``` 
to
```javascript
await etch.getScheduler().getNextUpdatePromise()
```

I also added a couple expect statements to verify that `update` methods on the child components were called since you were tracking. It was verified that they had NOT been called before `updateElement` was invoked, so I figured let's verify that they've been called afterward for the sake of closure (can you tell I'm a bit of a perfectionist? :stuck_out_tongue:)