### PR TITLE
Add `destroy` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ In addition to embedding other Etch components, you can pass an arbitrary constr
 * Your function must be a constructor. It will be called with the `new` keyword and passed the JSX expression's properties and children as arguments.
 * The component object returned by your constructor must have an `element` field pointing to a DOM node. This element will be inserted into the DOM.
 * The component object returned by your constructor may have an `update` method. This method will be called whenever the same function appears in the same location in successive calls to `render`.
+* The component object returned by your constructor may have a `destroy` method. This method will be called when the component is removed from the DOM. If you do any event binding to the DOM in your component, this is where you should clean it up.
 
 ### References
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ let taskList = new TaskListComponent({tasks: [
 ]})
 document.body.appendChild(taskList.element)
 taskList.addTask({id: 3, description: 'Feed cats', completed: false})
+
+// ... when we're done with our component and want to clean up:
+document.body.removeChild(taskList.element)
+taskList.destroy()
 ```
 
 Note that when we want to *use* the component, we don't have to interact with any Etch APIs. The component is an ordinary object that can be constructed normally. After construction, its `element` property points at a DOM node that is ready to use and can be appended to the document using standard APIs. This enables straightforward *interoperability* between our component and any code that works with standard DOM elements.

--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ let taskList = new TaskListComponent({tasks: [
 ]})
 document.body.appendChild(taskList.element)
 taskList.addTask({id: 3, description: 'Feed cats', completed: false})
-
-// ... when we're done with our component and want to clean up:
-document.body.removeChild(taskList.element)
-taskList.destroy()
 ```
 
 Note that when we want to *use* the component, we don't have to interact with any Etch APIs. The component is an ordinary object that can be constructed normally. After construction, its `element` property points at a DOM node that is ready to use and can be appended to the document using standard APIs. This enables straightforward *interoperability* between our component and any code that works with standard DOM elements.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In addition to embedding other Etch components, you can pass an arbitrary constr
 * Your function must be a constructor. It will be called with the `new` keyword and passed the JSX expression's properties and children as arguments.
 * The component object returned by your constructor must have an `element` field pointing to a DOM node. This element will be inserted into the DOM.
 * The component object returned by your constructor may have an `update` method. This method will be called whenever the same function appears in the same location in successive calls to `render`.
-* The component object returned by your constructor may have a `destroy` method. This method will be called when the component is removed from the DOM. If you do any event binding to the DOM in your component, this is where you should clean it up.
+* The component object returned by your constructor may have a `destroy` method. This method will be called when the component is removed from the DOM. If you need to perform any cleanup associated with removing your component's element from the DOM, you can do it here.
 
 ### References
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -12,6 +12,20 @@ export default function dom (tag, properties, ...children) {
   }
 }
 
+function recursivelyDestroyComponents(widget) {
+  let children
+  if (widget.component) {
+    children = widget.component.virtualElement.children
+  } else {
+    children = widget.children
+  }
+
+  children.forEach(recursivelyDestroyComponents)
+  if (widget.component && widget.component.destroy) {
+    widget.component.destroy()
+  }
+}
+
 class ComponentWidget {
   constructor (constructor, properties, children) {
     this.type = 'Widget'
@@ -63,6 +77,10 @@ class ComponentWidget {
       let newElement = this.init()
       oldElement.parentNode.replaceChild(newElement, oldElement)
     }
+  }
+
+  destroy (domNode) {
+    recursivelyDestroyComponents(this)
   }
 }
 

--- a/test/unit/update-element.test.js
+++ b/test/unit/update-element.test.js
@@ -45,4 +45,74 @@ describe('etch.updateElement(component)', () => {
     expect(component.refs.greeted.textContent).to.equal('World')
     expect(component.refs.greeting).to.be.undefined
   })
+
+  it('calls destroy() on removed components', async () => {
+    let childDestroyedOrder = 0
+    let greatGrandchildDestroyedOrder = 0
+    let destroyedCount = 0
+
+    class ParentComponent {
+      constructor () {
+        this.renderChild = true
+        etch.createElement(this)
+      }
+
+      render () {
+        if (this.renderChild) {
+          // test handles destroying components rendered via `children`
+          return <div><ChildComponent><GrandchildComponent /></ChildComponent></div>
+        } else {
+          return <div />
+        }
+      }
+    }
+
+    class ChildComponent {
+      constructor (props, children) {
+        this.children = children
+        etch.createElement(this)
+      }
+
+      render () {
+        return <div>{this.children}</div>
+      }
+
+      destroy () {
+        childDestroyedOrder = ++destroyedCount
+      }
+    }
+
+    class GrandchildComponent {
+      constructor () {
+        etch.createElement(this)
+      }
+
+      render () {
+        // test handles destroying components that are
+        // eventual children of plain DOM components
+        return <div><span><GreatGrandchildComponent /></span></div>
+      }
+    }
+
+    class GreatGrandchildComponent {
+      constructor () {
+        etch.createElement(this)
+      }
+
+      render () {
+        return <div />
+      }
+
+      destroy () {
+        greatGrandchildDestroyedOrder = ++destroyedCount
+      }
+    }
+
+    let component = new ParentComponent()
+    component.renderChild = false
+    await etch.updateElement(component)
+
+    expect(childDestroyedOrder).to.equal(2)
+    expect(greatGrandchildDestroyedOrder).to.equal(1)
+  })
 })


### PR DESCRIPTION
A component may define a `destroy` method which is called when a component is removed from the DOM as part of `performElementUpdate`. Etch will recurse into children and call any defined `destroy` hooks on them as well.