### PR TITLE
Throw when attempting to change a component's root DOM node type

### DIFF
--- a/src/perform-element-update.js
+++ b/src/perform-element-update.js
@@ -4,9 +4,13 @@ import refsStack from './refs-stack'
 
 export default function performElementUpdate (component) {
   let oldVirtualElement = component.virtualElement
+  let oldDomNode = component.element
   let newVirtualElement = component.render()
   refsStack.push(component.refs)
-  patch(component.element, diff(oldVirtualElement, newVirtualElement))
+  let newDomNode = patch(component.element, diff(oldVirtualElement, newVirtualElement))
   refsStack.pop()
   component.virtualElement = newVirtualElement
+  if (newDomNode !== oldDomNode) {
+    throw new Error("etch does not support changing the root DOM node type of a component")
+  }
 }

--- a/test/unit/update-element.test.js
+++ b/test/unit/update-element.test.js
@@ -45,4 +45,28 @@ describe('etch.updateElement(component)', () => {
     expect(component.refs.greeted.textContent).to.equal('World')
     expect(component.refs.greeting).to.be.undefined
   })
+
+  it('throws when attempting to change the top-level node type', () => {
+    class Component {
+      constructor () {
+        this.renderDiv = true
+        etch.createElement(this)
+      }
+
+      render () {
+        if (this.renderDiv) {
+          return <div />
+        } else {
+          return <span />
+        }
+      }
+    }
+
+    let component = new Component()
+    component.renderDiv = false
+
+    expect(() => {
+      etch.updateElementSync(component)
+    }).to.throw(/root DOM node type/)
+  })
 })


### PR DESCRIPTION
Since `patch` cannot actually patch a root-level DOM node, attempting to return a different type of node from `render` when updating the component results in a silent failure.

Instead, this PR implements an explicit exception that is thrown when this happens.

This fixes #10